### PR TITLE
fix multitenant config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ By default, you can use these variables to configure the module:
 Environment variable | Description | Default value
 --- | --- | ---
 `OMNIAUTH_PROVIDER` | The OAuth2 provider to use. Currently only `valid` is built-in in this plugin. Note that this word will be used as a prefix (in uppercase) for all the omniauth values defined after this. If you use a different provider, say `foo`, nexts ENV vars will start with `FOO_` instead of `VALID_` | `valid`
-`CUSTOM_LOGIN_SCREEN` | Whether to use a custom login screen or the default Decidim login screen. | `true`
+`CUSTOM_LOGIN_SCREEN` | Whether to use a custom login screen or the default Decidim login screen. | `true` (only if omniauth is enabled)
+`OMNIAUTH_ENABLED_BY_DEFAULT` | Whether the OAuth2 login is enabled by default. If false must be enabled in system. | `true` (if `VALID_CLIENT_ID` is present)
+`OMNIAUTH_GLOBAL_ATTRIBUTES` | Attributes sent to the Omniauth provider that are not writeable in the `/system` admin. Separated by spaces. | `site icon_path scope`
 `VALID_CLIENT_ID` | The OAuth2 client ID. Note that the prefix `VALID` is because `OMNIAUTH_PROVIDER` is set to "valid". Other values will require to name this variable accordingly (for instance `FOO_CLIENT_ID`). **IF this variable is empty, no OAuth login will be used**. | `nil`
 `VALID_CLIENT_SECRET` | The OAuth2 client secret. | `nil`
 `VALID_SITE` | The OAuth2 site. | `nil`

--- a/app/overrides/decidim/devise/sessions/new/hide_plain_login.rb
+++ b/app/overrides/decidim/devise/sessions/new/hide_plain_login.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Deface::Override.new(virtual_path: "decidim/devise/sessions/new",
-                     name: "hide-plain-login",
-                     set_attributes: ".row>.columns.large-6.medium-centered",
-                     attributes: { class: " columns large-6 medium-centered hide decidim-login" },
-                     disabled: !Decidim::TrustedIds.custom_login_screen?)

--- a/app/overrides/decidim/devise/sessions/new/remove_buttons.rb
+++ b/app/overrides/decidim/devise/sessions/new/remove_buttons.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Deface::Override.new(virtual_path: "decidim/devise/sessions/new",
-                     name: "remove-buttons",
-                     remove: "erb[silent]:contains('cache current_organization do')",
-                     closing_selector: "erb[silent]:contains('end')",
-                     disabled: !Decidim::TrustedIds.custom_login_screen?)

--- a/app/overrides/decidim/devise/sessions/new/replace_signup.rb
+++ b/app/overrides/decidim/devise/sessions/new/replace_signup.rb
@@ -2,6 +2,6 @@
 
 Deface::Override.new(virtual_path: "decidim/devise/sessions/new",
                      name: "replace-signup",
-                     replace: ".columns.large-8.large-centered.text-center.page-title",
+                     replace_contents: ".wrapper",
                      text: '<%= render "decidim/trusted_ids/devise/sessions/new" %>',
                      disabled: !Decidim::TrustedIds.custom_login_screen?)

--- a/app/views/decidim/trusted_ids/devise/sessions/_new.html.erb
+++ b/app/views/decidim/trusted_ids/devise/sessions/_new.html.erb
@@ -55,7 +55,7 @@
   <% end %>
 
   <% if current_organization.sign_in_enabled? %>
-    <div class="row decidim-login<%= ' hide ' if override_login %>">
+    <div class="row decidim-login<%= " hide " if override_login %>">
       <div class="columns large-6 medium-centered">
         <div class="card">
           <div class="card__content">

--- a/app/views/decidim/trusted_ids/devise/sessions/_new.html.erb
+++ b/app/views/decidim/trusted_ids/devise/sessions/_new.html.erb
@@ -1,24 +1,86 @@
 <%
   provider = Decidim::TrustedIds.omniauth_provider&.to_sym
   provider_str = t("decidim.authorization_handlers.trusted_ids_handler.name")
+  icon_path = current_organization.enabled_omniauth_providers[provider]&.dig(:icon_path)
+  override_login = Devise.mappings[:user].omniauthable? && current_organization.enabled_omniauth_providers&.include?(provider)
 %>
-<div class="columns large-6 large-centered page-title trusted-ids-login-box">
-  <h2><%= t(".login") %></h2>
-  <p><%= t(".login_subtitle") %></p>
-  <h6><%= t(".verified_identity", provider: provider_str) %></h6>
-  <%= t(".verified_identity_html") %>
-  <p><%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)}", method: :post do %>
-    <span class="button--social__icon">
-      <%= oauth_icon provider %>
-    </span>
-    <span class="button--social__text">
-      <%= t(".verified_login") %>
-    </span>
-  <% end %></p>
-  <hr>
-  <p><%= link_to t(".unverified_login"), "#", class: "button hollow secondary expanded", onclick: "document.querySelectorAll('.decidim-login').forEach((el) => el.classList.toggle('hide'));return false" %></p>
-</div>
 
-  <div class="decidim-login hide">
-    <%= render "decidim/trusted_ids/devise/sessions/omniauth_buttons" %>
+<div class="row collapse">
+  <div class="row collapse">
+    <div class="columns large-6 large-centered page-title trusted-ids-login-box">
+
+      <% if override_login %>
+        <h2><%= t(".login") %></h2>
+        <p><%= t(".login_subtitle") %></p>
+        <h6><%= t(".verified_identity", provider: provider_str) %></h6>
+        <%= t(".verified_identity_html") %>
+        <p><%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)}", method: :post do %>
+          <span class="button--social__icon">
+            <%= external_icon icon_path.presence || Decidim::TrustedIds.omniauth[:icon_path] %>
+          </span>
+          <span class="button--social__text">
+            <%= t(".verified_login") %>
+          </span>
+        <% end %></p>
+        <hr>
+        <p><%= link_to t(".unverified_login"), "#", class: "button hollow secondary expanded", onclick: "document.querySelectorAll('.decidim-login').forEach((el) => el.classList.toggle('hide'));return false" %></p>
+        <% else %>
+          <h1><%= t("devise.sessions.new.sign_in") %></h1>
+          <% if current_organization.sign_up_enabled? %>
+            <p>
+              <%= t("decidim.devise.sessions.new.are_you_new?") %>
+              <%= link_to t("decidim.devise.sessions.new.register"), new_user_registration_path %>
+            </p>
+          <% elsif current_organization.sign_in_enabled? %>
+            <p>
+              <%= t("decidim.devise.sessions.new.sign_up_disabled") %>
+            </p>
+          <% else %>
+            <p>
+              <%= t("decidim.devise.sessions.new.sign_in_disabled") %>
+            </p>
+          <% end %>
+      <% end %>
+    </div>
   </div>
+
+  <% if override_login %>
+    <div class="decidim-login hide">
+      <%= render "decidim/trusted_ids/devise/sessions/omniauth_buttons" %>
+    </div>
+  <% else %>
+    <% cache current_organization do %>
+      <%= render "decidim/devise/shared/omniauth_buttons" %>
+    <% end %>
+  <% end %>
+
+  <% if current_organization.sign_in_enabled? %>
+    <div class="row decidim-login<%= ' hide ' if override_login %>">
+      <div class="columns large-6 medium-centered">
+        <div class="card">
+          <div class="card__content">
+            <%= decidim_form_for(resource, namespace: "session", as: resource_name, url: session_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
+              <div>
+                <div class="field">
+                  <%= f.email_field :email, autocomplete: "email" %>
+                </div>
+                <div class="field">
+                  <%= f.password_field :password, autocomplete: "current-password" %>
+                </div>
+              </div>
+                <% if devise_mapping.rememberable? %>
+                  <div class="field">
+                    <%= f.check_box :remember_me %>
+                  </div>
+                <% end %>
+              <div class="actions">
+                <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
+              </div>
+            <% end %>
+            <%= render "decidim/devise/shared/links" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/lib/decidim/trusted_ids.rb
+++ b/lib/decidim/trusted_ids.rb
@@ -30,10 +30,6 @@ module Decidim
       ENV.fetch("OMNIAUTH_PROVIDER", "valid")
     end
 
-    config_accessor :custom_login_screen do
-      ENV.has_key?("CUSTOM_LOGIN_SCREEN") ? TrustedIds.to_bool(ENV.fetch("CUSTOM_LOGIN_SCREEN", true)) : true
-    end
-
     # From the data obtained we extract metadata to be saved as part of the authorization
     # This data can later be used by the census_authorization handler as to call the webservice
     # A hash with keys and how to find it inside hash comming from the OAuth
@@ -56,6 +52,16 @@ module Decidim
         icon_path: TrustedIds.omniauth_env("ICON", "media/images/#{TrustedIds.omniauth_provider.downcase}-icon.png"),
         scope: TrustedIds.omniauth_env("SCOPE", "autenticacio_usuari")
       }
+    end
+
+    # which of the former attributes can not set a the /system configuration, there are all the same for all tenants
+    config_accessor :omniauth_global_attributes do
+      ENV.fetch("OMNIAUTH_GLOBAL_ATTRIBUTES", "site icon_path scope").split.map(&:to_sym)
+    end
+
+    # wheter to us a custom login screen or the default one
+    config_accessor :custom_login_screen do
+      ENV.has_key?("CUSTOM_LOGIN_SCREEN") ? TrustedIds.to_bool(ENV.fetch("CUSTOM_LOGIN_SCREEN", true)) : TrustedIds.omniauth&.fetch(:enabled)
     end
 
     # how long the verification will be valid, defaults to 90 days

--- a/lib/decidim/trusted_ids.rb
+++ b/lib/decidim/trusted_ids.rb
@@ -45,7 +45,7 @@ module Decidim
     # setup a hash with :client_id, :client_secret and :site to enable omniauth authentication
     config_accessor :omniauth do
       {
-        enabled: TrustedIds.omniauth_env("CLIENT_ID").present?,
+        enabled: TrustedIds.to_bool(ENV.fetch("OMNIAUTH_ENABLED_BY_DEFAULT", TrustedIds.omniauth_env("CLIENT_ID").present?)),
         client_id: TrustedIds.omniauth_env("CLIENT_ID"),
         client_secret: TrustedIds.omniauth_env("CLIENT_SECRET"),
         site: TrustedIds.omniauth_env("SITE", "https://identitats.aoc.cat"),
@@ -59,9 +59,9 @@ module Decidim
       ENV.fetch("OMNIAUTH_GLOBAL_ATTRIBUTES", "site icon_path scope").split.map(&:to_sym)
     end
 
-    # wheter to us a custom login screen or the default one
+    # wheter to use a custom login screen or the default one
     config_accessor :custom_login_screen do
-      ENV.has_key?("CUSTOM_LOGIN_SCREEN") ? TrustedIds.to_bool(ENV.fetch("CUSTOM_LOGIN_SCREEN", true)) : TrustedIds.omniauth&.fetch(:enabled)
+      TrustedIds.to_bool(ENV.fetch("CUSTOM_LOGIN_SCREEN", true))
     end
 
     # how long the verification will be valid, defaults to 90 days

--- a/spec/lib/module_config_spec.rb
+++ b/spec/lib/module_config_spec.rb
@@ -34,6 +34,7 @@ module Decidim
     let(:env) do
       {
         "OMNIAUTH_PROVIDER" => provider,
+        "OMNIAUTH_GLOBAL_ATTRIBUTES" => global_attributes,
         "#{provider.upcase}_CLIENT_ID" => client_id,
         "#{provider.upcase}_CLIENT_SECRET" => client_secret,
         "#{provider.upcase}_SITE" => site,
@@ -44,6 +45,7 @@ module Decidim
       }
     end
     let(:provider) { "facebook" }
+    let(:global_attributes) { "site icon_path scope" }
     let(:client_id) { "client_id" }
     let(:client_secret) { "client_secret" }
     let(:site) { "https://example.org" }
@@ -70,6 +72,7 @@ module Decidim
                                "icon_path" => "icon_path/icon.png",
                                "scope" => "openid profile email"
                              },
+                             "omniauth_global_attributes" => %w(site icon_path scope),
                              "send_verification_notifications" => false,
                              "verification_expiration_time" => 90.days.to_i,
                              "authorization_metadata" => { "assurance_level" => %w(extra assurance_level), "expires_at" => %w(credentials expires_at), "identifier_type" => %w(extra identifier_type), "method" => %w(extra method) },
@@ -83,15 +86,19 @@ module Decidim
                            })
     end
 
-    it "has omniauth configured correctly" do
-      expect(omniauth_config["facebook"]).to eq({
-                                                  "enabled" => true,
-                                                  "client_id" => "client_id",
-                                                  "client_secret" => "client_secret",
-                                                  "site" => "https://example.org",
-                                                  "icon_path" => "icon_path/icon.png",
-                                                  "scope" => "openid profile email"
-                                                })
+    context "when some random provider" do
+      let(:global_attributes) { "" }
+
+      it "has omniauth configured correctly" do
+        expect(omniauth_config["facebook"]).to eq({
+                                                    "enabled" => true,
+                                                    "client_id" => "client_id",
+                                                    "client_secret" => "client_secret",
+                                                    "site" => "https://example.org",
+                                                    "icon_path" => "icon_path/icon.png",
+                                                    "scope" => "openid profile email"
+                                                  })
+      end
     end
 
     context "when valid provider" do
@@ -115,6 +122,7 @@ module Decidim
                                  "icon_path" => "media/images/valid-icon.png",
                                  "scope" => "autenticacio_usuari"
                                },
+                               "omniauth_global_attributes" => %w(site icon_path scope),
                                "send_verification_notifications" => true,
                                "verification_expiration_time" => 90.days.to_i,
                                "authorization_metadata" => { "assurance_level" => %w(extra assurance_level), "expires_at" => %w(credentials expires_at), "identifier_type" => %w(extra identifier_type), "method" => %w(extra method) },
@@ -132,10 +140,7 @@ module Decidim
         expect(omniauth_config["valid"]).to eq({
                                                  "enabled" => true,
                                                  "client_id" => "client_id",
-                                                 "client_secret" => "client_secret",
-                                                 "site" => "https://identitats.aoc.cat",
-                                                 "icon_path" => "media/images/valid-icon.png",
-                                                 "scope" => "autenticacio_usuari"
+                                                 "client_secret" => "client_secret"
                                                })
       end
     end
@@ -166,6 +171,7 @@ module Decidim
                                  "icon_path" => "media/images/valid-icon.png",
                                  "scope" => "autenticacio_usuari"
                                },
+                               "omniauth_global_attributes" => %w(site icon_path scope),
                                "send_verification_notifications" => true,
                                "verification_expiration_time" => 90.days.to_i,
                                "authorization_metadata" => { "" => %w(), "foo" => %w(inside) },
@@ -194,6 +200,7 @@ module Decidim
                                    "icon_path" => "media/images/facebook-icon.png",
                                    "scope" => "autenticacio_usuari"
                                  },
+                                 "omniauth_global_attributes" => %w(site icon_path scope),
                                  "send_verification_notifications" => true,
                                  "verification_expiration_time" => 90.days.to_i,
                                  "authorization_metadata" => { "bar" => %w(inside baz) },
@@ -224,6 +231,7 @@ module Decidim
                                  "icon_path" => "media/images/valid-icon.png",
                                  "scope" => "autenticacio_usuari"
                                },
+                               "omniauth_global_attributes" => %w(site icon_path scope),
                                "send_verification_notifications" => true,
                                "verification_expiration_time" => 90.days.to_i,
                                "authorization_metadata" => { "assurance_level" => %w(extra assurance_level), "expires_at" => %w(credentials expires_at), "identifier_type" => %w(extra identifier_type), "method" => %w(extra method) },
@@ -241,10 +249,7 @@ module Decidim
         expect(omniauth_config["valid"]).to eq({
                                                  "client_id" => nil,
                                                  "client_secret" => nil,
-                                                 "enabled" => false,
-                                                 "icon_path" => "media/images/valid-icon.png",
-                                                 "scope" => "autenticacio_usuari",
-                                                 "site" => "https://identitats.aoc.cat"
+                                                 "enabled" => false
                                                })
       end
     end


### PR DESCRIPTION
Adds several ENV vars for further configuration:

`CUSTOM_LOGIN_SCREEN`: Whether to use a custom login screen or the default Decidim login screen.
`OMNIAUTH_ENABLED_BY_DEFAULT`: Whether the OAuth2 login is enabled by default. If false must be enabled in system.
`OMNIAUTH_GLOBAL_ATTRIBUTES`: Attributes sent to the Omniauth provider that are not writeable in the `/system` admin. Separated by spaces.

Fixes the initializations of params for omniauth that was preventing to configured it from the tenant system admin