### PR TITLE
Do not cache sign in override

### DIFF
--- a/app/overrides/decidim/devise/sessions/new/replace_signup.html.erb.deface
+++ b/app/overrides/decidim/devise/sessions/new/replace_signup.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- replace_contents ".wrapper" -->
+
+<%= render "decidim/trusted_ids/devise/sessions/new" %>

--- a/app/overrides/decidim/devise/sessions/new/replace_signup.rb
+++ b/app/overrides/decidim/devise/sessions/new/replace_signup.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Deface::Override.new(virtual_path: "decidim/devise/sessions/new",
-                     name: "replace-signup",
-                     replace_contents: ".wrapper",
-                     text: '<%= render "decidim/trusted_ids/devise/sessions/new" %>',
-                     disabled: !Decidim::TrustedIds.custom_login_screen?)

--- a/app/views/decidim/trusted_ids/devise/sessions/_new.html.erb
+++ b/app/views/decidim/trusted_ids/devise/sessions/_new.html.erb
@@ -2,7 +2,7 @@
   provider = Decidim::TrustedIds.omniauth_provider&.to_sym
   provider_str = t("decidim.authorization_handlers.trusted_ids_handler.name")
   icon_path = current_organization.enabled_omniauth_providers[provider]&.dig(:icon_path)
-  override_login = Devise.mappings[:user].omniauthable? && current_organization.enabled_omniauth_providers&.include?(provider)
+  override_login = Decidim::TrustedIds.custom_login_screen? && Devise.mappings[:user].omniauthable? && current_organization.enabled_omniauth_providers&.include?(provider)
 %>
 
 <div class="row collapse">


### PR DESCRIPTION
When changing the configuration of the "use custom login screen" dynamically, it won't work if the condition is in when deface compiles the views. this puts the condition on the view