### PR TITLE
Set omniauth and valid buttons with secondary color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Following Semantic Versioning 2.
 
+## Version 0.8.2 (PATCH)
+- Change omniauth button styles for Vàlid from primary color to secondary.
+
 ## Version 0.8.1 (PATCH)
 - Fix omniauth button styles for Vàlid.
 - Show icon input in system for Vàlid omniauth settings. 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-trusted_ids (0.8.1)
+    decidim-trusted_ids (0.8.2)
       decidim (>= 0.28.0, < 0.29)
       decidim-core (>= 0.28.0, < 0.29)
       decidim-verifications (>= 0.28.0, < 0.29)

--- a/app/packs/stylesheets/decidim/trusted_ids/oauth_icons.scss
+++ b/app/packs/stylesheets/decidim/trusted_ids/oauth_icons.scss
@@ -31,18 +31,21 @@
 }
 
 .login__omniauth-button {
+  background-color: var(--secondary) !important;
+  border-color: var(--secondary) !important;
+
   img.icon.external-icon {
     display: inline-block !important;
   }
 }
 
 .login__omniauth-button > span {
-  color: var(--tertiary) !important;
+  color: white !important;
 }
 
 .button--social,
 .button--valid {
-  background-color: var(--primary);
+  background-color: var(--secondary);
   justify-content: start;
   align-items: center;
 }
@@ -50,6 +53,7 @@
 .button--unverified-login {
   border-color: var(--secondary);
   background-color: var(--secondary);
+  color: white;
 }
 
 .trusted-ids-login-box {

--- a/lib/decidim/trusted_ids/version.rb
+++ b/lib/decidim/trusted_ids/version.rb
@@ -3,7 +3,7 @@
 module Decidim
   # This holds the decidim-trusted_ids version.
   module TrustedIds
-    VERSION = "0.8.1"
+    VERSION = "0.8.2"
     DECIDIM_VERSION = "0.28.4"
     COMPAT_DECIDIM_VERSION = [">= 0.28.0", "< 0.29"].freeze
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Set omniauth and valid buttons with secondary color
 
<img width="1550" height="1007" alt="Screenshot from 2026-03-17 13-11-01" src="https://github.com/user-attachments/assets/e153df95-a21e-4e49-b706-61b45b882b55" />
<img width="1550" height="1007" alt="Screenshot from 2026-03-17 13-12-07" src="https://github.com/user-attachments/assets/6442c241-18ad-49f0-901a-ed2668e25a71" />

<img width="1550" height="1007" alt="Screenshot from 2026-03-17 13-12-55" src="https://github.com/user-attachments/assets/ef3370e7-d29b-405b-a512-ce3222f244ed" />
