### PR TITLE
Add validations to icon path in valid omniauth settings

### DIFF
--- a/.rubocop_ruby.yml
+++ b/.rubocop_ruby.yml
@@ -1228,7 +1228,7 @@ RSpec/DescribeClass:
     - spec/system/admin/manage_impersonations_spec.rb
     - spec/system/manual_verification_spec.rb
     - spec/system/oauth_login_spec.rb
-    - spec/system/system/*_organization_spec.rb
+    - spec/system/**/*
     - spec/system/via_oberta/**/*
 
 RSpec/EmptyExampleGroup:

--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ This module overrides the following Decidim core views and forms to provide the 
 
 - **`decidim/devise/sessions/new.html.erb`** — Overrides the login page to show a VÀLid button above the standard login form when the custom login screen is enabled.
 
-- **`decidim/devise/shared/_omniauth_buttons.html.erb`** — Overrides the shared omniauth buttons partial to rescue `Shakapacker::Manifest::MissingEntryError` when rendering provider icons. This ensures the registration (sign-up) page does not crash if a provider's icon file is missing from the asset manifest. When `icon_path` is blank (nil), the `oauth_icon` helper safely falls back to the registered `valid-fill` icon from Decidim's icon registry.
+- **`decidim/devise/shared/_omniauth_buttons.html.erb`** — Overrides the shared omniauth buttons partial. For the VÀLid provider, instead of calling `oauth_icon` (which falls back to the SVG `valid-fill` icon when `icon_path` is nil), the override reads `icon_path` from the organisation's omniauth settings and falls back to the default PNG (`media/images/valid-icon.png`) when not set. This means the PNG icon is always used for VÀLid on the sign-up / sign-in pages, even for organisations that were created before `icon_path` was a per-tenant field. The whole block is wrapped in a `rescue Shakapacker::Manifest::MissingEntryError` so the page never crashes if the asset is absent from the manifest.
 
-- **`decidim/system/organizations/_omniauth_provider.html.erb`** — Overrides the system admin omniauth provider settings partial to add a `placeholder` attribute to the `icon_path` field. The placeholder shows the default icon path (e.g. `media/images/valid-icon.png`), so admins understand that leaving the field blank will use that default at runtime.
+- **`decidim/system/organizations/_omniauth_provider.html.erb`** — Overrides the system admin omniauth provider settings partial to add a `placeholder` attribute to the `icon_path` field. The placeholder shows the default icon path (e.g. `media/images/valid-icon.png`), so admins understand that leaving the field blank will use that default on save.
 
 ### Forms
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,25 @@ For the complete list of available options, see the [trusted_ids](lib/decidim/tr
 - If the login screen is customized, it will look like this:
   ![Login screen](docs/login.png)
 
+## Decidim core overrides
+
+This module overrides the following Decidim core views and forms to provide the required behavior:
+
+### Views
+
+- **`decidim/devise/sessions/new.html.erb`** — Overrides the login page to show a VÀLid button above the standard login form when the custom login screen is enabled.
+
+- **`decidim/devise/shared/_omniauth_buttons.html.erb`** — Overrides the shared omniauth buttons partial to rescue `Shakapacker::Manifest::MissingEntryError` when rendering provider icons. This ensures the registration (sign-up) page does not crash if a provider's icon file is missing from the asset manifest. When `icon_path` is blank (nil), the `oauth_icon` helper safely falls back to the registered `valid-fill` icon from Decidim's icon registry.
+
+- **`decidim/system/organizations/_omniauth_provider.html.erb`** — Overrides the system admin omniauth provider settings partial to add a `placeholder` attribute to the `icon_path` field. The placeholder shows the default icon path (e.g. `media/images/valid-icon.png`), so admins understand that leaving the field blank will use that default at runtime.
+
+### Forms
+
+- **`Decidim::TrustedIds::System::OrganizationFormOverride`** — Included into `Decidim::System::RegisterOrganizationForm` and `Decidim::System::UpdateOrganizationForm`. Adds:
+  - Census configuration fields (expiration days, TOS, census settings).
+  - `validate_icon_path`: validates that if an `icon_path` is provided for the VÀLid provider, it must follow the `media/images/filename.ext` format and the file must exist in the module's `app/packs/images/` directory. This is future-proof: any new icon added there will automatically pass validation. Blank values are always accepted — on save, the encrypted default path is stored automatically.
+  - `EncryptedOmniauthSettingsOverride` (prepended module): when the VÀLid provider is being enabled and `icon_path` is blank, sets the default path (`media/images/valid-icon.png`) via the jsonb sub-attribute setter before calling `super`, so the core encrypts it and stores it in the database. This prevents `external_icon("")` from being called and crashing. Uses `prepend` so `super` correctly calls the core's `encrypted_omniauth_settings`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/ConsorciAOC-PRJ/decidim-module-trusted-ids.

--- a/app/forms/concerns/decidim/trusted_ids/system/organization_form_override.rb
+++ b/app/forms/concerns/decidim/trusted_ids/system/organization_form_override.rb
@@ -7,12 +7,40 @@ module Decidim
         extend ActiveSupport::Concern
         include Decidim::AttributeObject::TypeMap
 
+        # Prepended into the form class so that super() correctly resolves to
+        # the core's encrypted_omniauth_settings. When icon_path is blank, sets the
+        # default path via the jsonb sub-attribute setter BEFORE calling super, so
+        # the core picks it up and encrypts it correctly. Empty string would be truthy
+        # in omniauth_settings and cause oauth_icon → external_icon("") to crash.
+        module EncryptedOmniauthSettingsOverride
+          def encrypted_omniauth_settings
+            provider = Decidim::TrustedIds.omniauth_provider
+            icon_attr = :"omniauth_settings_#{provider}_icon_path"
+            enabled_attr = :"omniauth_settings_#{provider}_enabled"
+
+            # Only normalize blank icon_path when the provider is being enabled.
+            # If not enabled, we leave all settings blank so the core can return nil
+            # (preserving ENV-var-based configuration).
+            if public_send(enabled_attr) && public_send(icon_attr).blank?
+              default = Decidim::TrustedIds.omniauth[:icon_path].presence ||
+                        "media/images/#{provider.downcase}-icon.png"
+              public_send(:"#{icon_attr}=", default)
+            end
+
+            super
+          end
+        end
+
         included do
+          prepend EncryptedOmniauthSettingsOverride
+
           jsonb_attribute :trusted_ids_census_settings, TrustedIds.census_config_attributes
           attribute :trusted_ids_census_expiration_days, Integer
           translatable_attribute :trusted_ids_census_tos, String
           attribute :census_expiration_apply_all_tenants, Boolean
           attribute :census_tos_apply_all_tenants, Boolean
+
+          validate :validate_icon_path
 
           def map_model(model)
             self.secondary_hosts = model.secondary_hosts.join("\n")
@@ -29,6 +57,35 @@ module Decidim
           def default_expiration_days
             @default_expiration_days ||= Decidim::TrustedIds.verification_expiration_time.to_i / 86_400
           end
+
+          def default_icon_path
+            Decidim::TrustedIds.omniauth[:icon_path].presence ||
+              "media/images/#{Decidim::TrustedIds.omniauth_provider.downcase}-icon.png"
+          end
+        end
+
+        private
+
+        def validate_icon_path
+          # jsonb_attribute generates a getter method for each sub-field that handles
+          # both string and symbol hash keys. Use it instead of direct hash access.
+          icon_key = :"omniauth_settings_#{Decidim::TrustedIds.omniauth_provider}_icon_path"
+          path = public_send(icon_key)
+          return if path.blank? # blank = will use default on save, always valid
+
+          # Must follow the media/images/ format expected by Shakapacker
+          unless path.start_with?("media/images/")
+            errors.add(icon_key, :invalid_icon_path_format)
+            return
+          end
+
+          # File must exist in the module's registered assets images directory.
+          # This is future-proof: any new icon added to app/packs/images/ will
+          # automatically pass this validation without needing code changes.
+          filename = path.delete_prefix("media/images/")
+          file_exists = Decidim::TrustedIds::Engine.root.join("app/packs/images", filename).exist?
+
+          errors.add(icon_key, :icon_path_not_found) unless file_exists
         end
       end
     end

--- a/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -5,7 +5,17 @@
       <% link_classes = "login__omniauth-button button--#{normalize_provider_name(provider)}" %>
       <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: link_classes, method: :post, title: t("devise.shared.links.log_in_with_provider", provider: normalize_provider_name(provider).titleize) do %>
         <%= begin
-              oauth_icon provider
+              if provider.to_s == Decidim::TrustedIds.omniauth_provider.to_s
+                # For the VÀLid provider, fall back to the default PNG icon when
+                # icon_path is not configured in the organization's omniauth settings or in the module's omniauth settings.
+                settings = current_organization.enabled_omniauth_providers[provider]
+                icon_path = settings&.dig(:icon_path).presence ||
+                            Decidim::TrustedIds.omniauth[:icon_path].presence ||
+                            "media/images/#{Decidim::TrustedIds.omniauth_provider.downcase}-icon.png"
+                external_icon(icon_path)
+              else
+                oauth_icon provider
+              end
             rescue ::Shakapacker::Manifest::MissingEntryError
               nil
             end %>

--- a/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -1,0 +1,21 @@
+<% is_horizontal = false unless local_assigns.has_key?(:is_horizontal) %>
+<% if Devise.mappings[:user].omniauthable? && current_organization.enabled_omniauth_providers.any? %>
+  <div class="login__omniauth<%= " login__omniauth__horizontal" if is_horizontal %>">
+    <%- current_organization.enabled_omniauth_providers.keys.each do |provider| %>
+      <% link_classes = "login__omniauth-button button--#{normalize_provider_name(provider)}" %>
+      <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: link_classes, method: :post, title: t("devise.shared.links.log_in_with_provider", provider: normalize_provider_name(provider).titleize) do %>
+        <%= begin
+              oauth_icon provider
+            rescue ::Shakapacker::Manifest::MissingEntryError
+              nil
+            end %>
+        <span>
+          <%= normalize_provider_name(provider).titleize %>
+        </span>
+      <% end %>
+    <% end %>
+  </div>
+  <%- if current_organization.sign_in_enabled? %>
+    <span class="login__omniauth-separator"><%= t(".or") %></span>
+  <%- end %>
+<% end %>

--- a/app/views/decidim/system/organizations/_omniauth_provider.html.erb
+++ b/app/views/decidim/system/organizations/_omniauth_provider.html.erb
@@ -1,0 +1,31 @@
+<%
+  # Override of decidim-system's _omniauth_provider partial.
+  # Adds a placeholder to the icon_path field showing the default icon path value,
+  # so admins understand that leaving the field blank uses that default.
+  i18n_scope = "decidim.system.organizations.omniauth_settings"
+%>
+
+<%= field_set_tag f.label(provider_name(provider), nil, for: nil), class: "border-2 border-background p-4 form__wrapper last:pb-4" do %>
+  <% if provider_enabled?(provider) %>
+    <p class="help-text"><%= t("enabled_by_default", scope: i18n_scope) %></p>
+  <% end %>
+
+  <%= f.check_box(
+    "omniauth_settings_#{provider}_enabled",
+    label: t("enabled", scope: i18n_scope),
+    label_options: { class: "form__wrapper-checkbox-label" }
+  ) %>
+
+  <% Rails.application.secrets.dig(:omniauth, provider.to_sym).keys.select { |k| k != :enabled }.each do |setting| %>
+  <%
+    placeholder = if provider.to_s == Decidim::TrustedIds.omniauth_provider.to_s && setting.to_s == "icon_path"
+                    Decidim::TrustedIds.omniauth[:icon_path].presence ||
+                      "media/images/#{Decidim::TrustedIds.omniauth_provider.downcase}-icon.png"
+                  end
+  %>
+  <%= f.text_field("omniauth_settings_#{provider}_#{setting}", label: I18n.t(
+        ".#{setting}",
+        scope: "#{i18n_scope}.#{provider}"
+      ), placeholder: placeholder) %>
+  <% end %>
+<% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,6 +1,10 @@
 ---
 ca:
   activemodel:
+    errors:
+      messages:
+        invalid_icon_path_format: ha de tenir el format media/images/filename
+        icon_path_not_found: el fitxer de la icona no existeix a les rutes d'assets registrades
     attributes:
       trusted_ids_census_config:
         census_expiration_apply_all_tenants: 'Aplica a tots els "tenants" (això estableix els mateixos dies de caducitat per a totes les organitzacions d''aquesta plataforma). Avís: els valors buits també es propaguen'
@@ -49,7 +53,7 @@ ca:
           valid:
             client_id: Client ID
             client_secret: Clau secreta del Client
-            icon_path: Icona (sempre en format media/images/some-image.png)
+            icon_path: Ruta de la icona. Si és buit, agafarà la icona per defecte.
             scope: Àmbit
             site: URL del proveïdor
     trusted_ids:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,10 @@
 ---
 de:
   activemodel:
+    errors:
+      messages:
+        invalid_icon_path_format: must be in the format media/images/filename
+        icon_path_not_found: the icon file does not exist in the registered asset paths
     attributes:
       trusted_ids_census_config:
         census_expiration_apply_all_tenants: 'Apply to all tenants (this will set
@@ -62,7 +66,7 @@ de:
           valid:
             client_id: Client ID
             client_secret: Client secret
-            icon_path: Icon (always in the form of media/images/some-image.png)
+            icon_path: Icon path. If is empty, the default icon will be used.
             scope: Scope
             site: Provider URL
     trusted_ids:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,11 @@ en:
       via_oberta_handler:
         document_type: 'Could not be obtained automatically. Please select one from
           the list:'
+    errors:
+      messages:
+        icon_path_not_found: the icon file does not exist in the registered asset
+          paths
+        invalid_icon_path_format: must be in the format media/images/filename
   decidim:
     authorization_handlers:
       trusted_ids_handler:
@@ -62,7 +67,7 @@ en:
           valid:
             client_id: Client ID
             client_secret: Client secret
-            icon_path: Icon (always in the form of media/images/some-image.png)
+            icon_path: Icon path. If is empty, the default icon will be used.
             scope: Scope
             site: Provider URL
     trusted_ids:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,10 @@
 ---
 es:
   activemodel:
+    errors:
+      messages:
+        invalid_icon_path_format: debe tener el formato media/images/filename
+        icon_path_not_found: el archivo del icono no existe en las rutas de assets registradas
     attributes:
       trusted_ids_census_config:
         census_expiration_apply_all_tenants: 'Aplica a todos los "tenants" (esto establece los mismos días de caducidad para todas las organizaciones de esta plataforma). Aviso: los valores vacíos también se propagan'
@@ -49,7 +53,7 @@ es:
           valid:
             client_id: Client ID
             client_secret: Clave secreta del cliente
-            icon_path: Icono (siempre en formato media/images/some-image.png)
+            icon_path: Ruta del icono. Si se deja vacío, se usa el icono por defecto.
             scope: Ámbito
             site: URL del proveedor
     trusted_ids:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,6 +1,10 @@
 ---
 fr:
   activemodel:
+    errors:
+      messages:
+        invalid_icon_path_format: must be in the format media/images/filename
+        icon_path_not_found: the icon file does not exist in the registered asset paths
     attributes:
       trusted_ids_census_config:
         census_expiration_apply_all_tenants: 'Apply to all tenants (this will set
@@ -59,10 +63,10 @@ fr:
     system:
       organizations:
         omniauth_settings:
+          icon_path: Icon path. If is empty, the default icon will be used.
           valid:
             client_id: Client ID
             client_secret: Client secret
-            icon_path: Icon (always in the form of media/images/some-image.png)
             scope: Scope
             site: Provider URL
     trusted_ids:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,6 +1,10 @@
 ---
 it:
   activemodel:
+    errors:
+      messages:
+        invalid_icon_path_format: must be in the format media/images/filename
+        icon_path_not_found: the icon file does not exist in the registered asset paths
     attributes:
       trusted_ids_census_config:
         census_expiration_apply_all_tenants: 'Apply to all tenants (this will set
@@ -59,10 +63,10 @@ it:
     system:
       organizations:
         omniauth_settings:
+          icon_path: Icon path. If is empty, the default icon will be used.
           valid:
             client_id: Client ID
             client_secret: Client secret
-            icon_path: Icon (always in the form of media/images/some-image.png)
             scope: Scope
             site: Provider URL
     trusted_ids:

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -1,6 +1,10 @@
 ---
 oc:
   activemodel:
+    errors:
+      messages:
+        invalid_icon_path_format: deu aver lo format media/images/filename
+        icon_path_not_found: lo fichièr d'icòna existís pas dins los camins d'assets registrats
     attributes:
       trusted_ids_census_config:
         census_expiration_apply_all_tenants: 'Aplicar a totes los "tenants" (aquò establís los meteisses jorns de caducitat per a totas las organizacions d''aquesta plataforma). Avís: los valors voids tanben se propagan'
@@ -49,7 +53,7 @@ oc:
           valid:
             client_id: Client ID
             client_secret: Clau secreta del client
-            icon_path: Icòna (totjorn en format media/images/some-image.png)
+            icon_path: Icòna. Se es void, l'icòna per defaut serà utilizat.
             scope: Encastre
             site: URL del provesidor
     trusted_ids:

--- a/spec/forms/system/update_organization_form_spec.rb
+++ b/spec/forms/system/update_organization_form_spec.rb
@@ -60,5 +60,113 @@ module Decidim::System
         expect(subject.trusted_ids_census_tos).to eq(trusted_ids_census_config.tos)
       end
     end
+
+    describe "#default_icon_path" do
+      it "returns a path in media/images/ format" do
+        expect(subject.default_icon_path).to start_with("media/images/")
+      end
+    end
+
+    describe "icon_path validation" do
+      let(:icon_path_attr) { :omniauth_settings_valid_icon_path }
+
+      def form_with_icon_path(path)
+        described_class.new(
+          name: "Gotham City",
+          host: "decide.gotham.gov",
+          users_registration_mode: "enabled",
+          omniauth_settings_valid_icon_path: path
+        )
+      end
+
+      context "when icon_path is blank" do
+        it "is valid" do
+          expect(form_with_icon_path("")).to be_valid
+        end
+
+        it "is valid when nil" do
+          expect(form_with_icon_path(nil)).to be_valid
+        end
+      end
+
+      context "when icon_path has wrong format" do
+        let(:form) { form_with_icon_path("invalid/path.png") }
+
+        it "is not valid" do
+          expect(form).not_to be_valid
+        end
+
+        it "adds an error on the icon_path field" do
+          form.valid?
+          expect(form.errors[icon_path_attr]).to be_present
+        end
+      end
+
+      context "when icon_path points to a nonexistent file" do
+        let(:form) { form_with_icon_path("media/images/nonexistent-icon.png") }
+
+        it "is not valid" do
+          expect(form).not_to be_valid
+        end
+
+        it "adds an error on the icon_path field" do
+          form.valid?
+          expect(form.errors[icon_path_attr]).to be_present
+        end
+      end
+
+      context "when icon_path points to an existing file (valid-icon.png)" do
+        it "is valid" do
+          expect(form_with_icon_path("media/images/valid-icon.png")).to be_valid
+        end
+      end
+
+      context "when icon_path points to another existing file (idcat_mobil-icon.svg)" do
+        it "is valid" do
+          expect(form_with_icon_path("media/images/idcat_mobil-icon.svg")).to be_valid
+        end
+      end
+    end
+
+    describe "#encrypted_omniauth_settings" do
+      # attribute(:omniauth_settings, { String => Object }) coerces keys to strings,
+      # so the result hash uses string keys regardless of how they were set.
+      let(:icon_path_attr) { "omniauth_settings_valid_icon_path" }
+
+      context "when icon_path is blank and other settings are present" do
+        let(:form) do
+          described_class.new(
+            name: "Gotham City",
+            host: "decide.gotham.gov",
+            users_registration_mode: "enabled",
+            omniauth_settings_valid_enabled: true,
+            omniauth_settings_valid_icon_path: ""
+          )
+        end
+
+        it "stores the encrypted default icon path" do
+          result = form.encrypted_omniauth_settings
+          expect(result).not_to be_nil
+          stored = result[icon_path_attr]
+          expect(stored).to be_present
+          decrypted = Decidim::AttributeEncryptor.decrypt(stored)
+          expect(decrypted).to start_with("media/images/")
+        end
+      end
+
+      context "when all omniauth settings are blank" do
+        let(:form) do
+          described_class.new(
+            name: "Gotham City",
+            host: "decide.gotham.gov",
+            users_registration_mode: "enabled"
+          )
+        end
+
+        it "returns nil" do
+          expect(form.encrypted_omniauth_settings).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/shared/system_organization_examples.rb
+++ b/spec/shared/system_organization_examples.rb
@@ -28,6 +28,31 @@ shared_examples "updates organization" do
     expect(organization.trusted_ids_census_config.settings["municipal_code"]).to eq("33")
     expect(organization.trusted_ids_census_config.settings["province_code"]).to eq("44")
   end
+
+  context "when icon_path is left blank" do
+    it "saves successfully and stores the encrypted default icon path" do
+      fill_in "Name", with: "Citizens Rule!"
+      fill_in "Host", with: "www.example.org"
+      choose "Do not allow participants to register, but allow existing participants to login"
+      check "VÀLid (Direct)"
+
+      click_on "Show advanced settings"
+      # Clear the icon_path field to ensure it's blank
+      icon_input = find("input[name*='icon_path']", visible: :all)
+      icon_input.set("")
+
+      click_on "Save"
+
+      expect(page).to have_css("div.flash.success")
+      organization.reload
+      settings = organization.omniauth_settings
+      if settings.present?
+        stored = settings["omniauth_settings_valid_icon_path"]
+        expect(stored).to be_present
+        expect(Decidim::AttributeEncryptor.decrypt(stored)).to start_with("media/images/")
+      end
+    end
+  end
 end
 
 shared_examples "creates organization without census authorization fields" do
@@ -89,5 +114,13 @@ shared_examples "creates organization" do
     expect(organization.trusted_ids_census_config.settings["ine"]).to eq("22")
     expect(organization.trusted_ids_census_config.settings["municipal_code"]).to eq("33")
     expect(organization.trusted_ids_census_config.settings["province_code"]).to eq("44")
+
+    # icon_path should store the encrypted default path when not filled in
+    settings = organization.omniauth_settings
+    if settings.present?
+      stored = settings["omniauth_settings_valid_icon_path"]
+      expect(stored).to be_present
+      expect(Decidim::AttributeEncryptor.decrypt(stored)).to start_with("media/images/")
+    end
   end
 end

--- a/spec/system/omniauth_buttons_spec.rb
+++ b/spec/system/omniauth_buttons_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared/shared_contexts"
+
+describe "Omniauth buttons on registration page" do
+  include_context "with oauth configuration"
+
+  before do
+    switch_to_host(organization.host)
+    visit decidim.new_user_registration_path
+  end
+
+  it "shows the VÀLid button" do
+    expect(page).to have_css(".button--valid")
+  end
+
+  context "when icon_path is not set in the organization settings" do
+    let(:omniauth_settings) do
+      {
+        omniauth_settings_valid_enabled: enabled,
+        omniauth_settings_valid_client_id: Decidim::AttributeEncryptor.encrypt("CLIENT_ID"),
+        omniauth_settings_valid_client_secret: Decidim::AttributeEncryptor.encrypt("CLIENT_SECRET"),
+        omniauth_settings_valid_site: Decidim::AttributeEncryptor.encrypt("https://identitats-pre.aoc.cat"),
+        omniauth_settings_valid_scope: Decidim::AttributeEncryptor.encrypt("autenticacio_usuari")
+        # icon_path intentionally omitted — the override must fall back to the default PNG
+      }
+    end
+
+    it "renders the registration page without crashing" do
+      expect(page).to have_css(".button--valid")
+    end
+  end
+
+  context "when icon_path is an empty string (legacy data)" do
+    let(:omniauth_settings) do
+      {
+        omniauth_settings_valid_enabled: enabled,
+        omniauth_settings_valid_client_id: Decidim::AttributeEncryptor.encrypt("CLIENT_ID"),
+        omniauth_settings_valid_client_secret: Decidim::AttributeEncryptor.encrypt("CLIENT_SECRET"),
+        omniauth_settings_valid_site: Decidim::AttributeEncryptor.encrypt("https://identitats-pre.aoc.cat"),
+        omniauth_settings_valid_icon_path: Decidim::AttributeEncryptor.encrypt(""),
+        omniauth_settings_valid_scope: Decidim::AttributeEncryptor.encrypt("autenticacio_usuari")
+      }
+    end
+
+    it "renders the registration page without crashing" do
+      expect(page).to have_css(".button--valid")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Added support for a per-tenant icon_path field for the VÀLid omniauth provider in the system admin:

- The icon_path field is validated to follow the media/images/filename format and the file must exist in the module's app/packs/images/ directory. Blank values are always accepted.
- When the VÀLid provider is enabled and icon_path is left blank, the default path (media/images/valid-icon.png) is stored encrypted, preventing crashes from an empty string being passed to external_icon.
- Added a placeholder to the icon_path field so admins see the expected format, and fixed the i18n scope so the label resolves correctly under the valid provider key.
- For organizations that have no icon_path in the database (created before this field existed), the default PNG is used instead of falling back to the SVG valid-fill icon.
- Tests added/updated for form validation, encrypted settings behaviour, and the registration page rendering.
 
