### PR TITLE
Bump module version to 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Following Semantic Versioning 2.
 
+## Version 0.8.4 (PATCH)
+- Add validations to icon path in Vàlid omniauth settings
+
 ## Version 0.8.3 (PATCH)
 - Change VÀLid description in user's "Authorization methods".
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-trusted_ids (0.8.3)
+    decidim-trusted_ids (0.8.4)
       decidim (>= 0.28.0, < 0.29)
       decidim-core (>= 0.28.0, < 0.29)
       decidim-verifications (>= 0.28.0, < 0.29)

--- a/lib/decidim/trusted_ids/version.rb
+++ b/lib/decidim/trusted_ids/version.rb
@@ -3,7 +3,7 @@
 module Decidim
   # This holds the decidim-trusted_ids version.
   module TrustedIds
-    VERSION = "0.8.3"
+    VERSION = "0.8.4"
     DECIDIM_VERSION = "0.28.4"
     COMPAT_DECIDIM_VERSION = [">= 0.28.0", "< 0.29"].freeze
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Bump module version to 0.8.4 because forget in last PR https://github.com/ConsorciAOC-PRJ/decidim-module-trusted-ids/pull/41

